### PR TITLE
Fixed building on MacOS 10.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 # Create Executable
-add_executable(${PROJECT_TARGETBIN} ${GUI_TYPE} ${SRC} ${RESOURCES} ${FRAMEWORKS})
+add_executable(${PROJECT_TARGETBIN} ${GUI_TYPE} ${SRC} ${RESOURCES})
 if(WIN32)
   add_executable(${PROJECT_TARGETBIN}_Screensaver ${GUI_TYPE} ${SRC} ${RESOURCES} ${FRAMEWORKS})
   target_compile_definitions(${PROJECT_TARGETBIN}_Screensaver PRIVATE SCREENSAVER=1)


### PR DESCRIPTION
Removed FRAMEWORKS from main executable target because of the following error:

```cmake
CMake Error at CMakeLists.txt:149 (add_executable):
  Cannot find source file:

    /opt/local/lib/libSDL2main.a/opt/local/lib/libSDL2.dylib

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm
  .ccm .cxxm .c++m .h .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90
  .f95 .f03 .hip .ispc


CMake Error at CMakeLists.txt:149 (add_executable):
  No SOURCES given to target: GLMaze
```